### PR TITLE
Include payload by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ All you need to do is configure ActionMailer for smtp details. Add following con
 Resque::Failure::Notifier.configure do |config|
   config.from = 'dummy@dummy.com' # from address
   config.to = 'dummy@dummy.com' # to address
+  config.include_payload = true # enabled by default
 end
 ```
 

--- a/lib/resque_failed_job_mailer/resque/failure/notifier.rb
+++ b/lib/resque_failed_job_mailer/resque/failure/notifier.rb
@@ -8,6 +8,7 @@ module Resque
 
         def configure
           yield self
+          self.include_payload = true if include_payload.nil?
           Resque::Failure.backend = self unless Resque::Failure.backend == Resque::Failure::Multiple
         end
       end

--- a/spec/resque_failed_job_mailer_spec.rb
+++ b/spec/resque_failed_job_mailer_spec.rb
@@ -30,6 +30,10 @@ describe Resque::Failure::Notifier do
     it "should return recipient address" do
       Resque::Failure::Notifier.to.should == "dummy@dummy.com"
     end
+
+    it "should return default include_payload method" do
+      Resque::Failure::Notifier.include_payload.should be_true
+    end
   end
 
   describe "save" do


### PR DESCRIPTION
We're using this gem pretty extensively in our project and we were hit hard by this option of hidden payload in notification by default. Plus it wasn't mentioned in README

so this PR should fix this for ourselves and hopefully for others.
